### PR TITLE
Add simplecov to generate coverage report

### DIFF
--- a/presto-client.gemspec
+++ b/presto-client.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rake", [">= 0.9.2"]
   gem.add_development_dependency "rspec", ["~> 2.13.0"]
   gem.add_development_dependency "webmock", ["~> 1.16.1"]
+  gem.add_development_dependency "simplecov", ["~> 0.10.0"]
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,9 @@ rescue Bundler::BundlerError => e
   exit e.status_code
 end
 
+require 'simplecov'
+SimpleCov.start
+
 require 'json'
 require 'webmock/rspec'
 


### PR DESCRIPTION
`rake spec` generates coverage report under ./coverage/ directory.