### PR TITLE
Add ability to resume queries from their `next_uri`

### DIFF
--- a/lib/presto/client/client.rb
+++ b/lib/presto/client/client.rb
@@ -36,6 +36,10 @@ module Presto::Client
       end
     end
 
+    def resume_query(next_uri)
+      return Query.resume(next_uri, @options)
+    end
+
     def run(query)
       q = Query.start(query, @options)
       begin

--- a/lib/presto/client/query.rb
+++ b/lib/presto/client/query.rb
@@ -26,7 +26,7 @@ module Presto::Client
     end
 
     def self.resume(next_uri, options)
-      new StatementClient.new(faraday_client(options), nil, options, next_uri: next_uri)
+      new StatementClient.new(faraday_client(options), nil, options, next_uri)
     end
 
     def self.faraday_client(options)

--- a/lib/presto/client/statement_client.rb
+++ b/lib/presto/client/statement_client.rb
@@ -39,7 +39,7 @@ module Presto::Client
       "User-Agent" => "presto-ruby/#{VERSION}",
     }
 
-    def initialize(faraday, query, options)
+    def initialize(faraday, query, options, next_uri: nil)
       @faraday = faraday
       @faraday.headers.merge!(HEADERS)
 
@@ -47,7 +47,13 @@ module Presto::Client
       @query = query
       @closed = false
       @exception = nil
-      post_query_request!
+
+      if next_uri
+        body = faraday_get_with_retry(next_uri)
+        @results = Models::QueryResults.decode(MultiJson.load(body))
+      else
+        post_query_request!
+      end
     end
 
     def init_request(req)

--- a/lib/presto/client/statement_client.rb
+++ b/lib/presto/client/statement_client.rb
@@ -39,7 +39,7 @@ module Presto::Client
       "User-Agent" => "presto-ruby/#{VERSION}",
     }
 
-    def initialize(faraday, query, options, next_uri: nil)
+    def initialize(faraday, query, options, next_uri=nil)
       @faraday = faraday
       @faraday.headers.merge!(HEADERS)
 


### PR DESCRIPTION
This allows a query's state to be serialized and stored somewhere, then to be
resumed at a later point in time.

Notably, this means that Presto can be used with an API that supports queuing
a query and then polling for its status.