### PR TITLE
Raise exception when prestop api returns unexpected json

### DIFF
--- a/lib/presto/client/statement_client.rb
+++ b/lib/presto/client/statement_client.rb
@@ -138,7 +138,12 @@ module Presto::Client
       uri = @results.next_uri
 
       body = faraday_get_with_retry(uri)
-      @results = Models::QueryResults.decode(MultiJson.load(body))
+      json = MultiJson.load(body)
+      unless json.kind_of? Hash
+        @exception = PrestoHttpError.new(500, "Presto API error at #{uri} returned #{body}")
+        raise @exception
+      end
+      @results = Models::QueryResults.decode(json)
 
       return true
     end


### PR DESCRIPTION
We found a very rare case that `QueryResults` request returned an `Array` object out of nowhere. I guess it might have been an http error. For the future investigation we should raise an exception when the result is something that we don't expect.