### PR TITLE
Add optional headers for all query related HTTP requests

### DIFF
--- a/lib/presto/client/statement_client.rb
+++ b/lib/presto/client/statement_client.rb
@@ -44,10 +44,11 @@ module Presto::Client
       @faraday.headers.merge!(HEADERS)
 
       @options = options
-      @faraday.headers.merge!(optional_headers)
       @query = query
       @closed = false
       @exception = nil
+
+      @faraday.headers.merge!(optional_headers)
       post_query_request!
     end
 
@@ -76,6 +77,8 @@ module Presto::Client
       end
       headers
     end
+
+    private :optional_headers
 
     def init_request(req)
       req.options.timeout = @options[:http_timeout] || 300

--- a/lib/presto/client/statement_client.rb
+++ b/lib/presto/client/statement_client.rb
@@ -44,10 +44,37 @@ module Presto::Client
       @faraday.headers.merge!(HEADERS)
 
       @options = options
+      @faraday.headers.merge!(optional_headers)
       @query = query
       @closed = false
       @exception = nil
       post_query_request!
+    end
+
+    def optional_headers
+      headers = {}
+      if v = @options[:user]
+        headers[PrestoHeaders::PRESTO_USER] = v
+      end
+      if v = @options[:source]
+        headers[PrestoHeaders::PRESTO_SOURCE] = v
+      end
+      if v = @options[:catalog]
+        headers[PrestoHeaders::PRESTO_CATALOG] = v
+      end
+      if v = @options[:schema]
+        headers[PrestoHeaders::PRESTO_SCHEMA] = v
+      end
+      if v = @options[:time_zone]
+        headers[PrestoHeaders::PRESTO_TIME_ZONE] = v
+      end
+      if v = @options[:language]
+        headers[PrestoHeaders::PRESTO_LANGUAGE] = v
+      end
+      if v = @options[:properties]
+        headers[PrestoHeaders::PRESTO_SESSION] = encode_properties(v)
+      end
+      headers
     end
 
     def init_request(req)
@@ -60,28 +87,6 @@ module Presto::Client
     def post_query_request!
       response = @faraday.post do |req|
         req.url "/v1/statement"
-
-        if v = @options[:user]
-          req.headers[PrestoHeaders::PRESTO_USER] = v
-        end
-        if v = @options[:source]
-          req.headers[PrestoHeaders::PRESTO_SOURCE] = v
-        end
-        if v = @options[:catalog]
-          req.headers[PrestoHeaders::PRESTO_CATALOG] = v
-        end
-        if v = @options[:schema]
-          req.headers[PrestoHeaders::PRESTO_SCHEMA] = v
-        end
-        if v = @options[:time_zone]
-          req.headers[PrestoHeaders::PRESTO_TIME_ZONE] = v
-        end
-        if v = @options[:language]
-          req.headers[PrestoHeaders::PRESTO_LANGUAGE] = v
-        end
-        if v = @options[:properties]
-          req.headers[PrestoHeaders::PRESTO_SESSION] = encode_properties(v)
-        end
 
         req.body = @query
         init_request(req)

--- a/spec/statement_client_spec.rb
+++ b/spec/statement_client_spec.rb
@@ -67,6 +67,12 @@ describe Presto::Client::StatementClient do
     stub_request(:get, "localhost/v1/next_uri").
       with(headers: {
               "User-Agent" => "presto-ruby/#{VERSION}",
+              "X-Presto-Catalog" => options[:catalog],
+              "X-Presto-Schema" => options[:schema],
+              "X-Presto-User" => options[:user],
+              "X-Presto-Language" => options[:language],
+              "X-Presto-Time-Zone" => options[:time_zone],
+              "X-Presto-Session" => options[:properties].map {|k,v| "#{k}=#{v}"}.join("\r\nX-Presto-Session: ")
     }).to_return(body: lambda{|req|if retry_p; response_json.to_json; else; retry_p=true; raise Timeout::Error.new("execution expired"); end })
 
     faraday = Faraday.new(url: "http://localhost")
@@ -75,5 +81,6 @@ describe Presto::Client::StatementClient do
     sc.advance.should be_true
     retry_p.should be_true
   end
+
 end
 


### PR DESCRIPTION
No optional headers are appended other than `/v1/statement` request.
It might be better to have same headers for all request in case of proxy server for Presto cluster.