### PR TITLE
Support https schema option

### DIFF
--- a/lib/presto/client/query.rb
+++ b/lib/presto/client/query.rb
@@ -35,8 +35,10 @@ module Presto::Client
         raise ArgumentError, ":server option is required"
       end
 
+      schema = options[:port] == 443 ? "https" : "http"
+
       proxy = options[:http_proxy] || options[:proxy]  # :proxy is obsoleted
-      faraday = Faraday.new(url: "http://#{server}", proxy: "#{proxy}") do |faraday|
+      faraday = Faraday.new(url: "#{schema}://#{server}", proxy: "#{proxy}") do |faraday|
         #faraday.request :url_encoded
         faraday.response :logger if options[:http_debug]
         faraday.adapter Faraday.default_adapter

--- a/spec/statement_client_spec.rb
+++ b/spec/statement_client_spec.rb
@@ -101,5 +101,20 @@ describe Presto::Client::StatementClient do
       })
     end.should raise_error(TypeError, /String to Hash/)
   end
-end
 
+  it 'StatementClient send in https' do
+    stub_request(:post, "https://localhost/v1/statement").
+      with(body: query,
+           headers: {
+              "User-Agent" => "presto-ruby/#{VERSION}",
+              "X-Presto-Catalog" => options[:catalog],
+              "X-Presto-Schema" => options[:schema],
+              "X-Presto-User" => options[:user],
+              "X-Presto-Language" => options[:language],
+              "X-Presto-Time-Zone" => options[:time_zone],
+              "X-Presto-Session" => options[:properties].map {|k,v| "#{k}=#{v}"}.join("\r\nX-Presto-Session: ")
+    }).to_return(body: response_json.to_json)
+    options[:port] = 443
+    Query.start(query, options)
+  end
+end


### PR DESCRIPTION
When proxy server of Presto cluster support https, it can be better to provide a option to change request schema according to given port number.

This is related to #16.