### PR TITLE
Add SSL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ client = Presto::Client.new(
   },
   http_proxy: "proxy.example.com:8080",
   http_debug: true,
-})
+)
 
 # run a query and get results as an array of arrays:
 columns, rows = client.run("select * from sys.node")

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ require 'presto-client'
 # create a client object:
 client = Presto::Client.new(
   server: "localhost:8880",   # required option
-  ssl: false,
+  ssl: {verify: false}
   catalog: "native",
   schema: "default",
   user: "frsyuki",
@@ -23,7 +23,7 @@ client = Presto::Client.new(
   language: "English",
   properties: {
     "hive.force_local_scheduling": true,
-    "raptor.reader_stream_buffer_size: "32MB"
+    "raptor.reader_stream_buffer_size": "32MB"
   },
   http_proxy: "proxy.example.com:8080",
   http_debug: true,
@@ -62,12 +62,15 @@ end
 ## Options
 
 * **server** sets address (and port) of a Presto coordinator server.
-* **ssl** enables https. Setting `true` enables SSL and doesn't verify server certificate. Setting `:verify` verifies server certificate. Setting a Hash object enables SSL with following options:
-  * **ca_file**: path of a CA certification file in PEM format
-  * **ca_path**: path of a CA certification directory containing certifications in PEM format
-  * **cert_store**: a `OpenSSL::X509::Store` object used for verification
-  * **client_cert**: a `OpenSSL::X509::Certificate` object as client certificate
-  * **client_key**: a `OpenSSL::PKey::RSA` or `OpenSSL::PKey::DSA` object used for client certificate
+* **ssl** enables https.
+  * Setting `true` enables SSL and verifies server certificate using system's built-in certificates.
+  * Setting `{verify: false}` enables SSL but doesn't verify server certificate.
+  * Setting a Hash object enables SSL and verify server certificate with options:
+    * **ca_file**: path of a CA certification file in PEM format
+    * **ca_path**: path of a CA certification directory containing certifications in PEM format
+    * **cert_store**: a `OpenSSL::X509::Store` object used for verification
+    * **client_cert**: a `OpenSSL::X509::Certificate` object as client certificate
+    * **client_key**: a `OpenSSL::PKey::RSA` or `OpenSSL::PKey::DSA` object used for client certificate
 * **catalog** sets catalog (connector) name of Presto such as `hive-cdh4`, `hive-hadoop1`, etc.
 * **schema** sets default schema name of Presto. You need to use qualified name like `FROM myschema.table1` to use non-default schemas.
 * **source** sets source name to connect to a Presto. This name is shown on Presto web interface.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ require 'presto-client'
 # create a client object:
 client = Presto::Client.new(
   server: "localhost:8880",   # required option
-  ssl: {verify: false}
+  ssl: {verify: false},
   catalog: "native",
   schema: "default",
   user: "frsyuki",
@@ -27,7 +27,7 @@ client = Presto::Client.new(
   },
   http_proxy: "proxy.example.com:8080",
   http_debug: true,
-)
+})
 
 # run a query and get results as an array of arrays:
 columns, rows = client.run("select * from sys.node")

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ require 'presto-client'
 # create a client object:
 client = Presto::Client.new(
   server: "localhost:8880",   # required option
+  ssl: false,
   catalog: "native",
   schema: "default",
   user: "frsyuki",
@@ -61,6 +62,12 @@ end
 ## Options
 
 * **server** sets address (and port) of a Presto coordinator server.
+* **ssl** enables https. Setting `true` enables SSL and doesn't verify server certificate. Setting `:verify` verifies server certificate. Setting a Hash object enables SSL with following options:
+  * **ca_file**: path of a CA certification file in PEM format
+  * **ca_path**: path of a CA certification directory containing certifications in PEM format
+  * **cert_store**: a `OpenSSL::X509::Store` object used for verification
+  * **client_cert**: a `OpenSSL::X509::Certificate` object as client certificate
+  * **client_key**: a `OpenSSL::PKey::RSA` or `OpenSSL::PKey::DSA` object used for client certificate
 * **catalog** sets catalog (connector) name of Presto such as `hive-cdh4`, `hive-hadoop1`, etc.
 * **schema** sets default schema name of Presto. You need to use qualified name like `FROM myschema.table1` to use non-default schemas.
 * **source** sets source name to connect to a Presto. This name is shown on Presto web interface.

--- a/lib/presto/client/query.rb
+++ b/lib/presto/client/query.rb
@@ -35,19 +35,7 @@ module Presto::Client
         raise ArgumentError, ":server option is required"
       end
 
-      ssl = options[:ssl]
-      case ssl
-      when true
-        ssl = {verify: false}
-      when :verify, "verify"
-        ssl = {verify: true}
-      when Hash
-        # detailed SSL options. pass through to faraday
-      when nil, false
-        ssl = false
-      else
-        raise ArgumentError, "Can't convert #{ssl.class} of :ssl option to true, false, or Hash"
-      end
+      ssl = faraday_ssl_options(options)
 
       url = "#{ssl ? "https" : "http"}://#{server}"
       proxy = options[:http_proxy] || options[:proxy]  # :proxy is obsoleted
@@ -61,7 +49,35 @@ module Presto::Client
       return faraday
     end
 
-    private_class_method :faraday_client
+    def self.faraday_ssl_options(options)
+      ssl = options[:ssl]
+
+      case ssl
+      when true
+        ssl = {verify: true}
+
+      when Hash
+        verify = ssl.fetch(:verify, true)
+        case verify
+        when true
+          # detailed SSL options. pass through to faraday
+        when nil, false
+          ssl = {verify: false}
+        else
+          raise ArgumentError, "Can't convert #{verify.class} of :verify option of :ssl option to true or false"
+        end
+
+      when nil, false
+        ssl = false
+
+      else
+        raise ArgumentError, "Can't convert #{ssl.class} of :ssl option to true, false, or Hash"
+      end
+
+      return ssl
+    end
+
+    private_class_method :faraday_client, :faraday_ssl_options
 
     def initialize(api)
       @api = api

--- a/spec/statement_client_spec.rb
+++ b/spec/statement_client_spec.rb
@@ -116,16 +116,25 @@ describe Presto::Client::StatementClient do
         ssl: true,
       })
       f.url_prefix.to_s.should == "https://localhost/"
+      f.ssl.verify?.should == true
+    end
+
+    it "is enabled with ssl: {verify: false}" do
+      f = Query.__send__(:faraday_client, {
+        server: "localhost",
+        ssl: {verify: false}
+      })
+      f.url_prefix.to_s.should == "https://localhost/"
       f.ssl.verify?.should == false
     end
 
-    it "is enabled with ssl: :verify" do
-      f = Query.__send__(:faraday_client, {
-        server: "localhost",
-        ssl: :verify
-      })
-      f.url_prefix.to_s.should == "https://localhost/"
-      f.ssl.verify?.should == true
+    it "rejects invalid ssl: verify: object" do
+      lambda do
+        f = Query.__send__(:faraday_client, {
+          server: "localhost",
+          ssl: {verify: "??"}
+        })
+      end.should raise_error(ArgumentError, /String/)
     end
 
     it "is enabled with ssl: Hash" do
@@ -151,6 +160,24 @@ describe Presto::Client::StatementClient do
       f.ssl.cert_store.should == ssl[:cert_store]
       f.ssl.client_cert.should == ssl[:client_cert]
       f.ssl.client_key.should == ssl[:client_key]
+    end
+
+    it "rejects an invalid string" do
+      lambda do
+        Query.__send__(:faraday_client, {
+          server: "localhost",
+          ssl: '??',
+        })
+      end.should raise_error(ArgumentError, /String/)
+    end
+
+    it "rejects an integer" do
+      lambda do
+        Query.__send__(:faraday_client, {
+          server: "localhost",
+          ssl: 3,
+        })
+      end.should raise_error(ArgumentError, /:ssl/)
     end
   end
 end

--- a/spec/statement_client_spec.rb
+++ b/spec/statement_client_spec.rb
@@ -101,5 +101,57 @@ describe Presto::Client::StatementClient do
       })
     end.should raise_error(TypeError, /String to Hash/)
   end
+
+  describe "ssl" do
+    it "is disabled by default" do
+      f = Query.__send__(:faraday_client, {
+        server: "localhost",
+      })
+      f.url_prefix.to_s.should == "http://localhost/"
+    end
+
+    it "is enabled with ssl: true" do
+      f = Query.__send__(:faraday_client, {
+        server: "localhost",
+        ssl: true,
+      })
+      f.url_prefix.to_s.should == "https://localhost/"
+      f.ssl.verify?.should == false
+    end
+
+    it "is enabled with ssl: :verify" do
+      f = Query.__send__(:faraday_client, {
+        server: "localhost",
+        ssl: :verify
+      })
+      f.url_prefix.to_s.should == "https://localhost/"
+      f.ssl.verify?.should == true
+    end
+
+    it "is enabled with ssl: Hash" do
+      require 'openssl'
+
+      ssl = {
+        ca_file: "/path/to/dummy.pem",
+        ca_path: "/path/to/pemdir",
+        cert_store: OpenSSL::X509::Store.new,
+        client_cert: OpenSSL::X509::Certificate.new,
+        client_key: OpenSSL::PKey::DSA.new,
+      }
+
+      f = Query.__send__(:faraday_client, {
+        server: "localhost",
+        ssl: ssl,
+      })
+
+      f.url_prefix.to_s.should == "https://localhost/"
+      f.ssl.verify?.should == true
+      f.ssl.ca_file.should == ssl[:ca_file]
+      f.ssl.ca_path.should == ssl[:ca_path]
+      f.ssl.cert_store.should == ssl[:cert_store]
+      f.ssl.client_cert.should == ssl[:client_cert]
+      f.ssl.client_key.should == ssl[:client_key]
+    end
+  end
 end
 


### PR DESCRIPTION
Follow-up #20.
SSL support is useful when there is a HTTP proxy server in front of Presto coordinator for authentication, load-balancing, or fail-over purpose.