### PR TITLE
Fix uninitialized constant BlockedReason

### DIFF
--- a/lib/presto/client/model_versions/0.149.rb
+++ b/lib/presto/client/model_versions/0.149.rb
@@ -821,7 +821,7 @@ module Presto::Client::ModelVersions
           hash["finishUser"],
           hash["memoryReservation"],
           hash["systemMemoryReservation"],
-          hash["blockedReason"] && BlockedReason.decode(hash["blockedReason"]),
+          hash["blockedReason"] && hash["blockedReason"].downcase.to_sym,
           hash["info"],
         )
         obj

--- a/lib/presto/client/model_versions/0.153.rb
+++ b/lib/presto/client/model_versions/0.153.rb
@@ -838,7 +838,7 @@ module Presto::Client::ModelVersions
           hash["finishUser"],
           hash["memoryReservation"],
           hash["systemMemoryReservation"],
-          hash["blockedReason"] && BlockedReason.decode(hash["blockedReason"]),
+          hash["blockedReason"] && hash["blockedReason"].downcase.to_sym,
           hash["info"],
         )
         obj

--- a/modelgen/presto_models.rb
+++ b/modelgen/presto_models.rb
@@ -214,7 +214,7 @@ module PrestoModels
     def convert_expression(type, base_type, key)
       if @special_types[type]
         special.call(key)
-      elsif @enum_types.include?(type)
+      elsif @enum_types.include?(type) || @enum_types.include?(base_type)
         "#{key}.downcase.to_sym"
       elsif @primitive_types.include?(base_type)
         key

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe Presto::Client::Models do
+  describe 'rehash of BlockedReason' do
+    h = {
+      "operatorId" => 0,
+      "planNodeId" => "47",
+      "operatorType" => "ScanFilterAndProjectOperator",
+      "addInputCalls" => 0,
+      "addInputWall" => "0.00ns",
+      "addInputCpu" => "0.00ns",
+      "addInputUser" => "0.00ns",
+      "inputDataSize" => "9.46MB",
+      "inputPositions" => 440674,
+      "getOutputCalls" => 734,
+      "getOutputWall" => "7.29s",
+      "getOutputCpu" => "0.00ns",
+      "getOutputUser" => "0.00ns",
+      "outputDataSize" => "36.99MB",
+      "outputPositions" => 440674,
+      "blockedWall" => "0.00ns",
+      "finishCalls" => 0,
+      "finishWall" => "0.00ns",
+      "finishCpu" => "0.00ns",
+      "finishUser" => "0.00ns",
+      "memoryReservation" => "0B",
+      "systemMemoryReservation" => "0b",
+      "blockedReason" => "WAITING_FOR_MEMORY",
+      "info" => {"k" => "v"}
+    }
+
+    stats = Models::OperatorStats.decode(h)
+    stats.blocked_reason.should == :waiting_for_memory
+  end
+end


### PR DESCRIPTION
`BlockedReason` in `OperatorStats` is defined as optional. Therefore it is not generated as enum type due to matching failure. This can cause `uninitialized constant BlockedReason`.