### PR TITLE
Add connector id model to be generated

### DIFF
--- a/lib/presto/client/model_versions/0.153.rb
+++ b/lib/presto/client/model_versions/0.153.rb
@@ -623,6 +623,7 @@ module Presto::Client::ModelVersions
         end
         obj = allocate
         obj.send(:initialize_struct,
+          hash["connectorId"],
           hash["transactionHandle"],
           hash["connectorHandle"],
         )
@@ -679,6 +680,7 @@ module Presto::Client::ModelVersions
         end
         obj = allocate
         obj.send(:initialize_struct,
+          hash["connectorId"],
           hash["schema"],
           hash["table"],
           hash["connectorInfo"],
@@ -696,6 +698,7 @@ module Presto::Client::ModelVersions
         end
         obj = allocate
         obj.send(:initialize_struct,
+          hash["connectorId"],
           hash["transactionHandle"],
           hash["connectorHandle"],
         )
@@ -853,6 +856,7 @@ module Presto::Client::ModelVersions
         end
         obj = allocate
         obj.send(:initialize_struct,
+          hash["connectorId"],
           hash["schema"],
           hash["table"],
         )
@@ -907,6 +911,7 @@ module Presto::Client::ModelVersions
         end
         obj = allocate
         obj.send(:initialize_struct,
+          hash["connectorId"],
           hash["transactionHandle"],
           hash["connectorHandle"],
         )
@@ -955,6 +960,7 @@ module Presto::Client::ModelVersions
         end
         obj = allocate
         obj.send(:initialize_struct,
+          hash["connectorId"],
           hash["transactionHandle"],
           hash["connectorHandle"],
         )
@@ -1434,6 +1440,7 @@ module Presto::Client::ModelVersions
         end
         obj = allocate
         obj.send(:initialize_struct,
+          hash["connectorId"],
           hash["connectorHandle"],
         )
         obj
@@ -1448,6 +1455,7 @@ module Presto::Client::ModelVersions
         end
         obj = allocate
         obj.send(:initialize_struct,
+          hash["connectorId"],
           hash["transactionHandle"],
           hash["connectorHandle"],
         )

--- a/modelgen/modelgen.rb
+++ b/modelgen/modelgen.rb
@@ -16,7 +16,7 @@ source_path = source_dir
 predefined_simple_classes = %w[StageId TaskId ConnectorSession]
 predefined_models = %w[DistributionSnapshot PlanNode EquiJoinClause WriterTarget DeleteHandle Specification ArgumentBinding]
 
-assume_primitive = %w[Object Type Long Symbol QueryId PlanNodeId PlanFragmentId MemoryPoolId TransactionId URI Duration DataSize DateTime ColumnHandle ConnectorTableHandle ConnectorOutputTableHandle ConnectorIndexHandle ConnectorColumnHandle ConnectorInsertTableHandle ConnectorTableLayoutHandle Expression FunctionCall TimeZoneKey Locale TypeSignature Frame TupleDomain<ColumnHandle> SerializableNativeValue ConnectorTransactionHandle OutputBufferId ConnectorPartitioningHandle NullableValue]
+assume_primitive = %w[Object Type Long Symbol QueryId PlanNodeId PlanFragmentId MemoryPoolId TransactionId URI Duration DataSize DateTime ColumnHandle ConnectorTableHandle ConnectorOutputTableHandle ConnectorIndexHandle ConnectorColumnHandle ConnectorInsertTableHandle ConnectorTableLayoutHandle Expression FunctionCall TimeZoneKey Locale TypeSignature Frame TupleDomain<ColumnHandle> SerializableNativeValue ConnectorTransactionHandle OutputBufferId ConnectorPartitioningHandle NullableValue ConnectorId]
 enum_types = %w[QueryState StageState TaskState QueueState PlanDistribution OutputPartitioning Step SortOrder BufferState NullPartitioning BlockedReason ParameterKind FunctionKind PartitionFunctionHandle Scope ErrorType]
 
 root_models = %w[QueryResults QueryInfo] + %w[

--- a/spec/statement_client_spec.rb
+++ b/spec/statement_client_spec.rb
@@ -85,11 +85,13 @@ describe Presto::Client::StatementClient do
   it "decodes DeleteHandle" do
     dh = Models::DeleteHandle.decode({
       "handle" => {
+        "connectorId" => "c1",
         "connectorHandle" => {}
       }
     })
     dh.handle.should be_a_kind_of Models::TableHandle
-        dh.handle.connector_handle.should == nil
+    dh.handle.connector_id.should == "c1"
+    dh.handle.connector_handle.should == {}
   end
 
   it "validates models" do


### PR DESCRIPTION
From 0.153, connector id is created as a class. It should be passed to models which requires connector id.
https://github.com/prestodb/presto/blob/master/presto-main/src/main/java/com/facebook/presto/connector/ConnectorId.java