### PR TITLE
Fix compatibility with Faraday >= 0.12.0.

### DIFF
--- a/lib/presto/client/query.rb
+++ b/lib/presto/client/query.rb
@@ -30,6 +30,7 @@ module Presto::Client
     end
 
     def self.faraday_client(options)
+
       server = options[:server]
       unless server
         raise ArgumentError, ":server option is required"
@@ -40,7 +41,10 @@ module Presto::Client
       url = "#{ssl ? "https" : "http"}://#{server}"
       proxy = options[:http_proxy] || options[:proxy]  # :proxy is obsoleted
 
-      faraday = Faraday.new(url: url, proxy: "#{proxy}", ssl: ssl) do |faraday|
+      faraday_options = {url: url, proxy: "#{proxy}"}
+      faraday_options[:ssl] = ssl if ssl
+
+      faraday = Faraday.new(faraday_options) do |faraday|
         #faraday.request :url_encoded
         faraday.response :logger if options[:http_debug]
         faraday.adapter Faraday.default_adapter

--- a/presto-client.gemspec
+++ b/presto-client.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = ">= 1.9.1"
 
-  gem.add_dependency "faraday", ["~> 0.8"]
+  gem.add_dependency "faraday", ["~> 0.12"]
   gem.add_dependency "multi_json", ["~> 1.0"]
 
   gem.add_development_dependency "rake", [">= 0.9.2", "< 11.0"]


### PR DESCRIPTION
Without this change, I receive the following error using Faraday >= 0.12.0:
```
/Users/myuser/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/faraday-0.12.0.1/lib/faraday/options.rb:49:in `merge!': undefined method `each' for false:FalseClass (NoMethodError)
	from /Users/myuser/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/faraday-0.12.0.1/lib/faraday/options.rb:60:in `merge'
	from /Users/myuser/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/faraday-0.12.0.1/lib/faraday/options.rb:52:in `block in merge!'
	from /Users/myuser/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/faraday-0.12.0.1/lib/faraday/options.rb:49:in `each'
	from /Users/myuser/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/faraday-0.12.0.1/lib/faraday/options.rb:49:in `merge!'
	from /Users/myuser/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/faraday-0.12.0.1/lib/faraday/options.rb:60:in `merge'
	from /Users/myuser/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/faraday-0.12.0.1/lib/faraday/connection.rb:61:in `initialize'
	from /Users/myuser/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/faraday-0.12.0.1/lib/faraday.rb:67:in `new'
	from /Users/myuser/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/faraday-0.12.0.1/lib/faraday.rb:67:in `new'
	from /Users/myuser/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/presto-client-0.5.2/lib/presto/client/query.rb:43:in `faraday_client'
	from /Users/myuser/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/presto-client-0.5.2/lib/presto/client/query.rb:25:in `start'
	from /Users/myuser/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/presto-client-0.5.2/lib/presto/client/client.rb:44:in `run'
  ...
```

It seems the `ssl` parameter to a new Faraday client must either be a Hash or not specified at all now.