### PR TITLE
Add support for MessagePack response body

### DIFF
--- a/lib/presto/client/query.rb
+++ b/lib/presto/client/query.rb
@@ -30,7 +30,6 @@ module Presto::Client
     end
 
     def self.faraday_client(options)
-
       server = options[:server]
       unless server
         raise ArgumentError, ":server option is required"

--- a/lib/presto/client/statement_client.rb
+++ b/lib/presto/client/statement_client.rb
@@ -93,7 +93,7 @@ module Presto::Client
         # not officially supported by Presto. We can use this option only if a proxy server
         # decodes & encodes response body. Once this option is supported by Presto, option
         # name should be enable_msgpack, which might be slightly different behavior.
-        headers['Accept'] = 'application/x-msgpack, application/json'
+        headers['Accept'] = 'application/x-msgpack,application/json'
       end
       headers
     end

--- a/lib/presto/client/statement_client.rb
+++ b/lib/presto/client/statement_client.rb
@@ -93,7 +93,7 @@ module Presto::Client
         # not officially supported by Presto. We can use this option only if a proxy server
         # decodes & encodes response body. Once this option is supported by Presto, option
         # name should be enable_msgpack, which might be slightly different behavior.
-        headers['Accept'] = 'application/x-msgpack'
+        headers['Accept'] = 'application/x-msgpack, application/json'
       end
       headers
     end
@@ -118,7 +118,7 @@ module Presto::Client
 
       # TODO error handling
       if response.status != 200
-        raise PrestoHttpError.new(response.status, "Failed to start query: #{response.body}")
+        raise PrestoHttpError.new(response.status, "Failed to start query: #{response.body} (#{response.status})")
       end
 
       @results = decode_model(uri, parse_body(response), @models::QueryResults)

--- a/presto-client.gemspec
+++ b/presto-client.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "faraday", ["~> 0.12"]
   gem.add_dependency "multi_json", ["~> 1.0"]
+  gem.add_dependency "msgpack", [">= 0.7.0"]
 
   gem.add_development_dependency "rake", [">= 0.9.2", "< 11.0"]
   gem.add_development_dependency "rspec", ["~> 2.13.0"]

--- a/spec/statement_client_spec.rb
+++ b/spec/statement_client_spec.rb
@@ -94,7 +94,7 @@ describe Presto::Client::StatementClient do
               "X-Presto-Language" => options[:language],
               "X-Presto-Time-Zone" => options[:time_zone],
               "X-Presto-Session" => options[:properties].map {|k,v| "#{k}=#{v}"}.join("\r\nX-Presto-Session: "),
-              "Accept" => "application/x-msgpack, application/json"
+              "Accept" => "application/x-msgpack,application/json"
     }).to_return(body: MessagePack.dump(response_json2), headers: {"Content-Type" => "application/x-msgpack"})
 
     stub_request(:get, "localhost/v1/next_uri").
@@ -106,7 +106,7 @@ describe Presto::Client::StatementClient do
               "X-Presto-Language" => options[:language],
               "X-Presto-Time-Zone" => options[:time_zone],
               "X-Presto-Session" => options[:properties].map {|k,v| "#{k}=#{v}"}.join("\r\nX-Presto-Session: "),
-              "Accept" => "application/x-msgpack, application/json"
+              "Accept" => "application/x-msgpack,application/json"
     }).to_return(body: lambda{|req|if retry_p; MessagePack.dump(response_json); else; retry_p=true; raise Timeout::Error.new("execution expired"); end }, headers: {"Content-Type" => "application/x-msgpack"})
 
     faraday = Faraday.new(url: "http://localhost")

--- a/spec/statement_client_spec.rb
+++ b/spec/statement_client_spec.rb
@@ -94,7 +94,7 @@ describe Presto::Client::StatementClient do
               "X-Presto-Language" => options[:language],
               "X-Presto-Time-Zone" => options[:time_zone],
               "X-Presto-Session" => options[:properties].map {|k,v| "#{k}=#{v}"}.join("\r\nX-Presto-Session: "),
-              "Accept" => "application/x-msgpack"
+              "Accept" => "application/x-msgpack, application/json"
     }).to_return(body: MessagePack.dump(response_json2), headers: {"Content-Type" => "application/x-msgpack"})
 
     stub_request(:get, "localhost/v1/next_uri").
@@ -106,7 +106,7 @@ describe Presto::Client::StatementClient do
               "X-Presto-Language" => options[:language],
               "X-Presto-Time-Zone" => options[:time_zone],
               "X-Presto-Session" => options[:properties].map {|k,v| "#{k}=#{v}"}.join("\r\nX-Presto-Session: "),
-              "Accept" => "application/x-msgpack"
+              "Accept" => "application/x-msgpack, application/json"
     }).to_return(body: lambda{|req|if retry_p; MessagePack.dump(response_json); else; retry_p=true; raise Timeout::Error.new("execution expired"); end }, headers: {"Content-Type" => "application/x-msgpack"})
 
     faraday = Faraday.new(url: "http://localhost")

--- a/spec/statement_client_spec.rb
+++ b/spec/statement_client_spec.rb
@@ -82,6 +82,40 @@ describe Presto::Client::StatementClient do
     retry_p.should be_true
   end
 
+  it "uses 'Accept: application/x-msgpack' if option is set" do
+    retry_p = false
+    stub_request(:post, "localhost/v1/statement").
+      with(body: query,
+           headers: {
+              "User-Agent" => "presto-ruby/#{VERSION}",
+              "X-Presto-Catalog" => options[:catalog],
+              "X-Presto-Schema" => options[:schema],
+              "X-Presto-User" => options[:user],
+              "X-Presto-Language" => options[:language],
+              "X-Presto-Time-Zone" => options[:time_zone],
+              "X-Presto-Session" => options[:properties].map {|k,v| "#{k}=#{v}"}.join("\r\nX-Presto-Session: "),
+              "Accept" => "application/x-msgpack"
+    }).to_return(body: MessagePack.dump(response_json2), headers: {"Content-Type" => "application/x-msgpack"})
+
+    stub_request(:get, "localhost/v1/next_uri").
+      with(headers: {
+              "User-Agent" => "presto-ruby/#{VERSION}",
+              "X-Presto-Catalog" => options[:catalog],
+              "X-Presto-Schema" => options[:schema],
+              "X-Presto-User" => options[:user],
+              "X-Presto-Language" => options[:language],
+              "X-Presto-Time-Zone" => options[:time_zone],
+              "X-Presto-Session" => options[:properties].map {|k,v| "#{k}=#{v}"}.join("\r\nX-Presto-Session: "),
+              "Accept" => "application/x-msgpack"
+    }).to_return(body: lambda{|req|if retry_p; MessagePack.dump(response_json); else; retry_p=true; raise Timeout::Error.new("execution expired"); end }, headers: {"Content-Type" => "application/x-msgpack"})
+
+    faraday = Faraday.new(url: "http://localhost")
+    sc = StatementClient.new(faraday, query, options.merge(http_open_timeout: 1, enable_x_msgpack: "application/x-msgpack"))
+    sc.has_next?.should be_true
+    sc.advance.should be_true
+    retry_p.should be_true
+  end
+
   it "decodes DeleteHandle" do
     dh = Models::DeleteHandle.decode({
       "handle" => {


### PR DESCRIPTION
[MessagePack](http://msgpack.org/) is a drop-in replacement of JSON for faster and smaller
object serialization. With this change, this Presto client parses response
body as MessagePack if Presto sends the response with
`Content-Type: application/x-msgpack` header. In addition to it, if
enable_x_msgpack option is set, this Presto client sends a request with
`Accept: application/x-msgpack` header.

Notice that MessagePack encoding is not fully supported by Presto. We can enjoy this optimization if there is a proxy server between Presto and client and it transcodes JSON to MessagePack.

This optimization is effective especially for Ruby because deserialization cost is relatively high compared to JVM. An example of memory profile (ruby-prof with ALLOCATIONS mode) in 3 minutes showed this result:

```
 %self      total      self      wait     child     calls  name
 93.32  4620474.000 4620474.000     0.000     0.000       94   <Module::Oj>#load
  0.84  41610.000 41610.000     0.000     0.000    20805   OpenSSL::SSL::SSLSocket#sysread_nonblock
  0.78  38512.000 38512.000     0.000     0.000    12999   String#slice!
  0.42  62415.000 20805.000     0.000 41610.000    20805   OpenSSL::Buffering#read_nonblock
  0.26  13491.000 12653.000   838.000     0.000     6239   Zlib::Inflate#inflate
  0.24  11835.000 11835.000     0.000     0.000    11835   Integer#to_s
  0.23  157976.000 11421.000    10.000 146545.000     5709   Net::BufferedIO#read
```

A micro benchmark shows that number of memory allocations of msgpack-ruby is 1.5 times fewer.

JSON (Oj.load):

```
Measure Mode: allocations
Thread ID: 70106046784840
Fiber ID: 70106059206780
Total: 142500001.000000
Sort by: self_time

 %self      total      self      wait     child     calls  name
 99.65  142000000.000 142000000.000     0.000     0.000   100000   <Module::Oj>#load
  0.21  300000.000 300000.000     0.000     0.000   100000   <Class::IO>#read
  0.07  100000.000 100000.000     0.000     0.000   100000   Integer#to_s
  0.07  142500000.000 100000.000     0.000 142400000.000        1   Integer#times
  0.00  142500001.000     1.000     0.000 142500000.000        1   Global#[No method]

* indicates recursively called methods

real    1m48.546s
user    0m46.888s
sys     0m15.997s
```

MessagePack (MessagePack.load):

```
msgpack 100000
Measure Mode: allocations
Thread ID: 70228780508440
Fiber ID: 70228780839700
Total: 93100001.000000
Sort by: self_time

 %self      total      self      wait     child     calls  name
 99.46  92600000.000 92600000.000     0.000     0.000   100000   <Module::MessagePack>#load
  0.32  300000.000 300000.000     0.000     0.000   100000   <Class::IO>#read
  0.11  100000.000 100000.000     0.000     0.000   100000   Integer#to_s
  0.11  93100000.000 100000.000     0.000 93000000.000        1   Integer#times
  0.00  93100001.000     1.000     0.000 93100000.000        1   Global#[No method]

* indicates recursively called methods

real    1m3.928s
user    0m28.360s
sys     0m6.119s
```
