### PR TITLE
Support a password option with HTTP basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ client = Presto::Client.new(
   catalog: "native",
   schema: "default",
   user: "frsyuki",
+  password: "********",
   time_zone: "US/Pacific",
   language: "English",
   properties: {
@@ -81,6 +82,7 @@ $ bundle exec rake modelgen:latest
 * **schema** sets default schema name of Presto. You need to use qualified name like `FROM myschema.table1` to use non-default schemas.
 * **source** sets source name to connect to a Presto. This name is shown on Presto web interface.
 * **user** sets user name to connect to a Presto.
+* **password** sets a password to connect to Presto using basic auth.
 * **time_zone** sets time zone of queries. Time zone affects some functions such as `format_datetime`.
 * **language** sets language of queries. Language affects some functions such as `format_datetime`.
 * **properties** set session properties. Session properties affect internal behavior such as `hive.force_local_scheduling: true`, `raptor.reader_stream_buffer_size: "32MB"`, etc.

--- a/lib/presto/client/query.rb
+++ b/lib/presto/client/query.rb
@@ -37,6 +37,10 @@ module Presto::Client
 
       ssl = faraday_ssl_options(options)
 
+      if options[:password] && !ssl
+        raise ArgumentError, "Protocol must be https when passing a password"
+      end
+
       url = "#{ssl ? "https" : "http"}://#{server}"
       proxy = options[:http_proxy] || options[:proxy]  # :proxy is obsoleted
 
@@ -45,6 +49,11 @@ module Presto::Client
 
       faraday = Faraday.new(faraday_options) do |faraday|
         #faraday.request :url_encoded
+
+        if options[:user] && options[:password]
+          faraday.basic_auth(options[:user], options[:password])
+        end
+
         faraday.response :logger if options[:http_debug]
         faraday.adapter Faraday.default_adapter
       end

--- a/presto-client.gemspec
+++ b/presto-client.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "rake", [">= 0.9.2", "< 11.0"]
   gem.add_development_dependency "rspec", ["~> 2.13.0"]
-  gem.add_development_dependency "webmock", ["~> 1.16.1"]
+  gem.add_development_dependency "webmock", ["~> 2.0.0"]
   gem.add_development_dependency "addressable", ["~> 2.4.0"] # 2.5.0 doesn't support Ruby 1.9.3
   gem.add_development_dependency "simplecov", ["~> 0.10.0"]
 end


### PR DESCRIPTION
- Adds support for basic auth by passing in a password option
- If a password option is set, https must be enabled