### PR TITLE
Fix too deep nested json failure

### DIFF
--- a/lib/presto/client/statement_client.rb
+++ b/lib/presto/client/statement_client.rb
@@ -15,7 +15,7 @@
 #
 module Presto::Client
 
-  require 'multi_json'
+  require 'json'
   require 'msgpack'
   require 'presto/client/models'
   require 'presto/client/errors'
@@ -38,6 +38,11 @@ module Presto::Client
   class StatementClient
     HEADERS = {
       "User-Agent" => "presto-ruby/#{VERSION}",
+    }
+
+    # Presto can return too deep nested JSON
+    JSON_OPTIONS = {
+        :max_nesting => false
     }
 
     def initialize(faraday, query, options, next_uri=nil)
@@ -195,7 +200,7 @@ module Presto::Client
       when 'application/x-msgpack'
         MessagePack.load(response.body)
       else
-        MultiJson.load(response.body)
+        JSON.parse(response.body, opts = JSON_OPTIONS)
       end
     end
 

--- a/presto-client.gemspec
+++ b/presto-client.gemspec
@@ -20,8 +20,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 1.9.1"
 
   gem.add_dependency "faraday", ["~> 0.12"]
-  gem.add_dependency "multi_json", ["~> 1.0"]
-  gem.add_dependency "msgpack", [">= 0.7.0"]
+    gem.add_dependency "msgpack", [">= 0.7.0"]
 
   gem.add_development_dependency "rake", [">= 0.9.2", "< 11.0"]
   gem.add_development_dependency "rspec", ["~> 2.13.0"]


### PR DESCRIPTION
## Problem

Presto can return too nested JSON value in statement request when huge `UNION ALL` or `JOIN` query is submitted.

```
     Failure/Error: StatementClient.new(faraday, query, options)
     JSON::NestingError:
       nesting of 101 is too deep
     # ./lib/presto/client/statement_client.rb:198:in `parse_body'
     # ./lib/presto/client/statement_client.rb:124:in `post_query_request!'
     # ./lib/presto/client/statement_client.rb:64:in `initialize'
     # ./spec/statement_client_spec.rb:294:in `new'
     # ./spec/statement_client_spec.rb:294:in `block (2 levels) in <top (required)>'
```

## Solution

Disabling depth checking in this case should be safe.