### PR TITLE
Query#each should raise an exception if underlaying query fails

### DIFF
--- a/lib/presto/client/query.rb
+++ b/lib/presto/client/query.rb
@@ -152,6 +152,8 @@ module Presto::Client
           block.call(data)
         end
       end while @api.advance
+
+      raise_if_failed
     end
 
     def query_info


### PR DESCRIPTION
`Query#each` iterates through some rows and finished without exception
when Presto returned a response with 200 OK response and next_uri=nil
and a failure status set in error field. This happens when a query was
canceled successfully during an iteration.
We easily miss checking of the final query status after iteration of the
rows (even README doesn't have one). This change adds the check at the
end of #each so that iteration fails with an exception.