### PR TITLE
Add a method to kill a query by query id

### DIFF
--- a/lib/presto/client/client.rb
+++ b/lib/presto/client/client.rb
@@ -40,6 +40,10 @@ module Presto::Client
       return Query.resume(next_uri, @options)
     end
 
+    def cancel_query_id(query_id)
+      return Query.cancel_id(query_id, @options)
+    end
+
     def run(query)
       q = Query.start(query, @options)
       begin

--- a/lib/presto/client/client.rb
+++ b/lib/presto/client/client.rb
@@ -40,8 +40,8 @@ module Presto::Client
       return Query.resume(next_uri, @options)
     end
 
-    def cancel_query_id(query_id)
-      return Query.cancel_id(query_id, @options)
+    def kill(query_id)
+      return Query.kill(query_id, @options)
     end
 
     def run(query)

--- a/lib/presto/client/faraday_client.rb
+++ b/lib/presto/client/faraday_client.rb
@@ -53,8 +53,6 @@ module Presto::Client
     faraday_options[:ssl] = ssl if ssl
 
     faraday = Faraday.new(faraday_options) do |faraday|
-      #faraday.request :url_encoded
-
       if options[:user] && options[:password]
         faraday.basic_auth(options[:user], options[:password])
       end

--- a/lib/presto/client/faraday_client.rb
+++ b/lib/presto/client/faraday_client.rb
@@ -1,0 +1,156 @@
+#
+# Presto client for Ruby
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+module Presto::Client
+
+  module PrestoHeaders
+    PRESTO_USER = "X-Presto-User"
+    PRESTO_SOURCE = "X-Presto-Source"
+    PRESTO_CATALOG = "X-Presto-Catalog"
+    PRESTO_SCHEMA = "X-Presto-Schema"
+    PRESTO_TIME_ZONE = "X-Presto-Time-Zone"
+    PRESTO_LANGUAGE = "X-Presto-Language"
+    PRESTO_SESSION = "X-Presto-Session"
+
+    PRESTO_CURRENT_STATE = "X-Presto-Current-State"
+    PRESTO_MAX_WAIT = "X-Presto-Max-Wait"
+    PRESTO_MAX_SIZE = "X-Presto-Max-Size"
+    PRESTO_PAGE_SEQUENCE_ID = "X-Presto-Page-Sequence-Id"
+  end
+
+  HEADERS = {
+    "User-Agent" => "presto-ruby/#{VERSION}",
+  }
+
+  def self.faraday_client(options)
+    server = options[:server]
+    unless server
+      raise ArgumentError, ":server option is required"
+    end
+
+    ssl = faraday_ssl_options(options)
+
+    if options[:password] && !ssl
+      raise ArgumentError, "Protocol must be https when passing a password"
+    end
+
+    url = "#{ssl ? "https" : "http"}://#{server}"
+    proxy = options[:http_proxy] || options[:proxy]  # :proxy is obsoleted
+
+    faraday_options = {url: url, proxy: "#{proxy}"}
+    faraday_options[:ssl] = ssl if ssl
+
+    faraday = Faraday.new(faraday_options) do |faraday|
+      #faraday.request :url_encoded
+
+      if options[:user] && options[:password]
+        faraday.basic_auth(options[:user], options[:password])
+      end
+
+      faraday.response :logger if options[:http_debug]
+      faraday.adapter Faraday.default_adapter
+    end
+
+    faraday.headers.merge!(HEADERS)
+    faraday.headers.merge!(optional_headers(options))
+
+    return faraday
+  end
+
+  def self.faraday_ssl_options(options)
+    ssl = options[:ssl]
+
+    case ssl
+    when true
+      ssl = {verify: true}
+
+    when Hash
+      verify = ssl.fetch(:verify, true)
+      case verify
+      when true
+        # detailed SSL options. pass through to faraday
+      when nil, false
+        ssl = {verify: false}
+      else
+        raise ArgumentError, "Can't convert #{verify.class} of :verify option of :ssl option to true or false"
+      end
+
+    when nil, false
+      ssl = false
+
+    else
+      raise ArgumentError, "Can't convert #{ssl.class} of :ssl option to true, false, or Hash"
+    end
+
+    return ssl
+  end
+
+  def self.optional_headers(options)
+    headers = {}
+    if v = options[:user]
+      headers[PrestoHeaders::PRESTO_USER] = v
+    end
+    if v = options[:source]
+      headers[PrestoHeaders::PRESTO_SOURCE] = v
+    end
+    if v = options[:catalog]
+      headers[PrestoHeaders::PRESTO_CATALOG] = v
+    end
+    if v = options[:schema]
+      headers[PrestoHeaders::PRESTO_SCHEMA] = v
+    end
+    if v = options[:time_zone]
+      headers[PrestoHeaders::PRESTO_TIME_ZONE] = v
+    end
+    if v = options[:language]
+      headers[PrestoHeaders::PRESTO_LANGUAGE] = v
+    end
+    if v = options[:properties]
+      headers[PrestoHeaders::PRESTO_SESSION] = encode_properties(v)
+    end
+    if options[:enable_x_msgpack]
+      # option name is enable_"x"_msgpack because "Accept: application/x-msgpack" header is
+      # not officially supported by Presto. We can use this option only if a proxy server
+      # decodes & encodes response body. Once this option is supported by Presto, option
+      # name should be enable_msgpack, which might be slightly different behavior.
+      headers['Accept'] = 'application/x-msgpack,application/json'
+    end
+    headers
+  end
+
+  HTTP11_SEPARATOR = ["(", ")", "<", ">", "@", ",", ";", ":", "\\", "<", ">", "/", "[", "]", "?", "=", "{", "}", " ", "\v"]
+  HTTP11_TOKEN_CHARSET = (32..126).map {|x| x.chr } - HTTP11_SEPARATOR
+  HTTP11_TOKEN_REGEXP = /^[#{Regexp.escape(HTTP11_TOKEN_CHARSET.join)}]+\z/
+  HTTP11_CTL_CHARSET = (0..31).map {|x| x.chr } + [127.chr]
+  HTTP11_CTL_CHARSET_REGEXP = /[#{Regexp.escape(HTTP11_CTL_CHARSET.join)}]/
+
+  def self.encode_properties(properties)
+    # this is a hack to set same header multiple times.
+    properties.map do |k, v|
+      token = k.to_s
+      field_value = v.to_s  # TODO LWS encoding is not implemented
+      unless k =~ HTTP11_TOKEN_REGEXP
+        raise Faraday::ClientError, "Key of properties can't include HTTP/1.1 control characters or separators (#{HTTP11_SEPARATOR.map {|c| c =~ /\s/ ? c.dump : c }.join(' ')})"
+      end
+      if field_value =~ HTTP11_CTL_CHARSET_REGEXP
+        raise Faraday::ClientError, "Value of properties can't include HTTP/1.1 control characters"
+      end
+      "#{token}=#{field_value}"
+    end.join("\r\n#{PrestoHeaders::PRESTO_SESSION}: ")
+  end
+
+  private_class_method :faraday_ssl_options, :optional_headers, :encode_properties
+
+end

--- a/lib/presto/client/query.rb
+++ b/lib/presto/client/query.rb
@@ -30,6 +30,14 @@ module Presto::Client
       new StatementClient.new(faraday_client(options), nil, options, next_uri)
     end
 
+    def self.cancel_id(query_id, options)
+      faraday = faraday_client(options)
+      response = faraday.delete do |req|
+        req.url "/v1/query/#{query_id}"
+      end
+      return response.status / 100 == 2
+    end
+
     def self.faraday_client(options)
       Presto::Client.faraday_client(options)
     end

--- a/lib/presto/client/query.rb
+++ b/lib/presto/client/query.rb
@@ -18,6 +18,7 @@ module Presto::Client
   require 'faraday'
   require 'presto/client/models'
   require 'presto/client/errors'
+  require 'presto/client/faraday_client'
   require 'presto/client/statement_client'
 
   class Query
@@ -30,66 +31,8 @@ module Presto::Client
     end
 
     def self.faraday_client(options)
-      server = options[:server]
-      unless server
-        raise ArgumentError, ":server option is required"
-      end
-
-      ssl = faraday_ssl_options(options)
-
-      if options[:password] && !ssl
-        raise ArgumentError, "Protocol must be https when passing a password"
-      end
-
-      url = "#{ssl ? "https" : "http"}://#{server}"
-      proxy = options[:http_proxy] || options[:proxy]  # :proxy is obsoleted
-
-      faraday_options = {url: url, proxy: "#{proxy}"}
-      faraday_options[:ssl] = ssl if ssl
-
-      faraday = Faraday.new(faraday_options) do |faraday|
-        #faraday.request :url_encoded
-
-        if options[:user] && options[:password]
-          faraday.basic_auth(options[:user], options[:password])
-        end
-
-        faraday.response :logger if options[:http_debug]
-        faraday.adapter Faraday.default_adapter
-      end
-
-      return faraday
+      Presto::Client.faraday_client(options)
     end
-
-    def self.faraday_ssl_options(options)
-      ssl = options[:ssl]
-
-      case ssl
-      when true
-        ssl = {verify: true}
-
-      when Hash
-        verify = ssl.fetch(:verify, true)
-        case verify
-        when true
-          # detailed SSL options. pass through to faraday
-        when nil, false
-          ssl = {verify: false}
-        else
-          raise ArgumentError, "Can't convert #{verify.class} of :verify option of :ssl option to true or false"
-        end
-
-      when nil, false
-        ssl = false
-
-      else
-        raise ArgumentError, "Can't convert #{ssl.class} of :ssl option to true, false, or Hash"
-      end
-
-      return ssl
-    end
-
-    private_class_method :faraday_client, :faraday_ssl_options
 
     def initialize(api)
       @api = api

--- a/lib/presto/client/query.rb
+++ b/lib/presto/client/query.rb
@@ -30,7 +30,7 @@ module Presto::Client
       new StatementClient.new(faraday_client(options), nil, options, next_uri)
     end
 
-    def self.cancel_id(query_id, options)
+    def self.kill(query_id, options)
       faraday = faraday_client(options)
       response = faraday.delete do |req|
         req.url "/v1/query/#{query_id}"

--- a/spec/statement_client_spec.rb
+++ b/spec/statement_client_spec.rb
@@ -166,7 +166,7 @@ describe Presto::Client::StatementClient do
     end
   end
 
-  describe "Canceling query" do
+  describe "Killing a query" do
     let(:query_id) { 'A_QUERY_ID' }
 
     it "sends DELETE request with empty body to /v1/query/{queryId}" do
@@ -182,7 +182,7 @@ describe Presto::Client::StatementClient do
                 "X-Presto-Session" => options[:properties].map {|k,v| "#{k}=#{v}"}.join("\r\nX-Presto-Session: "),
       }).to_return(body: {}.to_json)
 
-      Presto::Client.new(options).cancel_query_id(query_id)
+      Presto::Client.new(options).kill(query_id)
     end
   end
 

--- a/spec/statement_client_spec.rb
+++ b/spec/statement_client_spec.rb
@@ -25,6 +25,10 @@ describe Presto::Client::StatementClient do
     }
   end
 
+  let :faraday do
+    Presto::Client.faraday_client(options)
+  end
+
   it "sets headers" do
     stub_request(:post, "localhost/v1/statement").
       with(body: query,
@@ -38,7 +42,6 @@ describe Presto::Client::StatementClient do
               "X-Presto-Session" => options[:properties].map {|k,v| "#{k}=#{v}"}.join("\r\nX-Presto-Session: ")
     }).to_return(body: response_json.to_json)
 
-    faraday = Faraday.new(url: "http://localhost")
     StatementClient.new(faraday, query, options)
   end
 
@@ -75,7 +78,6 @@ describe Presto::Client::StatementClient do
               "X-Presto-Session" => options[:properties].map {|k,v| "#{k}=#{v}"}.join("\r\nX-Presto-Session: ")
     }).to_return(body: lambda{|req|if retry_p; response_json.to_json; else; retry_p=true; raise Timeout::Error.new("execution expired"); end })
 
-    faraday = Faraday.new(url: "http://localhost")
     sc = StatementClient.new(faraday, query, options.merge(http_open_timeout: 1))
     sc.has_next?.should be_true
     sc.advance.should be_true
@@ -109,8 +111,8 @@ describe Presto::Client::StatementClient do
               "Accept" => "application/x-msgpack,application/json"
     }).to_return(body: lambda{|req|if retry_p; MessagePack.dump(response_json); else; retry_p=true; raise Timeout::Error.new("execution expired"); end }, headers: {"Content-Type" => "application/x-msgpack"})
 
-    faraday = Faraday.new(url: "http://localhost")
-    sc = StatementClient.new(faraday, query, options.merge(http_open_timeout: 1, enable_x_msgpack: "application/x-msgpack"))
+    options.merge!(http_open_timeout: 1, enable_x_msgpack: "application/x-msgpack")
+    sc = StatementClient.new(faraday, query, options)
     sc.has_next?.should be_true
     sc.advance.should be_true
     retry_p.should be_true
@@ -183,7 +185,7 @@ describe Presto::Client::StatementClient do
             basic_auth: [options[:user], password]
       ).to_return(body: response_json.to_json)
 
-      faraday = Query.__send__(:faraday_client, options.merge(ssl: { verify: true }, password: password))
+      options.merge!(ssl: { verify: true }, password: password)
       StatementClient.new(faraday, query, options)
     end
 
@@ -318,7 +320,6 @@ describe Presto::Client::StatementClient do
                  "X-Presto-Session" => options[:properties].map {|k,v| "#{k}=#{v}"}.join("\r\nX-Presto-Session: ")
              }).to_return(body: nested_json.to_json(:max_nesting => false))
 
-    faraday = Faraday.new(url: "http://localhost")
     StatementClient.new(faraday, query, options)
   end
 end


### PR DESCRIPTION
`next_uri` is available only for the thread who is polling the result.
When the thread is actively polling next_uri and another thread/process
wants to kill the query, `Query.resume(next_uri).cancel` doesn't work
because next_uri won't be guaranteed to be the latest URI and Presto may
return `410 Gone`.
This adds another API to kill a query without race condition by using
query id.

This PR consists of 2 changes: refactoring (c7d99765695f30992e1277f052698981c86b4d63) and main change (9054cf0d4841baaf5c154e679d5d964fbe8f8e00).