### PR TITLE
Support multiple session properties in Ruby 2.5

### DIFF
--- a/lib/presto/client/faraday_client.rb
+++ b/lib/presto/client/faraday_client.rb
@@ -146,7 +146,6 @@ module Presto::Client
   HTTP11_CTL_CHARSET_REGEXP = /[#{Regexp.escape(HTTP11_CTL_CHARSET.join)}]/
 
   def self.encode_properties(properties)
-    # this is a hack to set same header multiple times.
     properties.map do |k, v|
       token = k.to_s
       field_value = v.to_s  # TODO LWS encoding is not implemented
@@ -157,7 +156,7 @@ module Presto::Client
         raise Faraday::ClientError, "Value of properties can't include HTTP/1.1 control characters"
       end
       "#{token}=#{field_value}"
-    end.join("\r\n#{PrestoHeaders::PRESTO_SESSION}: ")
+    end
   end
 
   def self.encode_client_info(info)

--- a/spec/statement_client_spec.rb
+++ b/spec/statement_client_spec.rb
@@ -196,7 +196,7 @@ describe Presto::Client::StatementClient do
       stub_request(:post, "localhost/v1/statement").
         with(body: query,
              headers: headers.merge({
-               "X-Presto-Session" => options[:properties].map {|k,v| "#{k}=#{v}"}.join("\r\nX-Presto-Session: ")
+               "X-Presto-Session" => options[:properties].map {|k,v| "#{k}=#{v}"}.join(", ")
              })).
         to_return(body: response_json.to_json)
 


### PR DESCRIPTION
Comma-separated style should be used to specify multiple values because HTTP headers which include CR/LF are not allowed in Ruby 2.5.
cf. https://bugs.ruby-lang.org/issues/14208

The current implementation was introduced in c76d8548a621808f9a11978e01d426fa3d0ea1f6, but I don't know the reason why it uses CR/LF.
RFC 2616 says 'It MUST be possible to combine the multiple header fields into one "field-name: field-value" pair'.
cf. https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2

I've checked the behavior using the following code:

```ruby
require "presto-client"

client = Presto::Client.new(
  server: "localhost:8889",
  user: "arabiki",
  properties: {
    "exchange_compression": true,
    "hive.bucket_execution_enabled": false,
  },
  http_debug: true,
)

columns, rows = client.run("select 1")
rows.each {|row|
  p row
}
```

## Before

```
% bundle exec ruby -Ilib example.rb
I, [2018-05-23T18:50:45.096776 #71143]  INFO -- request: POST http://localhost:8889/v1/statement
D, [2018-05-23T18:50:45.096862 #71143] DEBUG -- request: User-Agent: "presto-ruby/0.5.10"
X-Presto-User: "arabiki"
X-Presto-Session: "exchange_compression=true\r\nX-Presto-Session: hive.bucket_execution_enabled=false"
Traceback (most recent call last):
        20: from example.rb:13:in `<main>'
        19: from /Users/arabiki/ghq/src/github.com/treasure-data/presto-client-ruby/lib/presto/client/client.rb:48:in `run'
        18: from /Users/arabiki/ghq/src/github.com/treasure-data/presto-client-ruby/lib/presto/client/query.rb:26:in `start'
        17: from /Users/arabiki/ghq/src/github.com/treasure-data/presto-client-ruby/lib/presto/client/query.rb:26:in `new'
        16: from /Users/arabiki/ghq/src/github.com/treasure-data/presto-client-ruby/lib/presto/client/statement_client.rb:47:in `initialize'
        15: from /Users/arabiki/ghq/src/github.com/treasure-data/presto-client-ruby/lib/presto/client/statement_client.rb:60:in `post_query_request!'
        14: from /Users/arabiki/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/faraday-0.15.1/lib/faraday/connection.rb:175:in `post'
        13: from /Users/arabiki/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/faraday-0.15.1/lib/faraday/connection.rb:387:in `run_request'
        12: from /Users/arabiki/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/faraday-0.15.1/lib/faraday/rack_builder.rb:143:in `build_response'
        11: from /Users/arabiki/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/faraday-0.15.1/lib/faraday/response/logger.rb:26:in `call'
        10: from /Users/arabiki/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/faraday-0.15.1/lib/faraday/response.rb:8:in `call'
         9: from /Users/arabiki/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/faraday-0.15.1/lib/faraday/adapter/net_http.rb:38:in `call'
         8: from /Users/arabiki/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/faraday-0.15.1/lib/faraday/adapter/net_http.rb:92:in `with_net_http_connection'
         7: from /Users/arabiki/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/faraday-0.15.1/lib/faraday/adapter/net_http.rb:43:in `block in call'
         6: from /Users/arabiki/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/faraday-0.15.1/lib/faraday/adapter/net_http.rb:87:in `perform_request'
         5: from /Users/arabiki/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/faraday-0.15.1/lib/faraday/adapter/net_http.rb:67:in `create_request'
         4: from /Users/arabiki/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/faraday-0.15.1/lib/faraday/adapter/net_http.rb:67:in `new'
         3: from /Users/arabiki/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/2.5.0/net/http/generic_request.rb:44:in `initialize'
         2: from /Users/arabiki/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/2.5.0/net/http/header.rb:16:in `initialize_http_header'
         1: from /Users/arabiki/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/2.5.0/net/http/header.rb:16:in `each'
/Users/arabiki/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/2.5.0/net/http/header.rb:23:in `block in initialize_http_header': header field value cannot include CR/LF (ArgumentError)
```

## After

```
% bundle exec ruby -Ilib example.rb
I, [2018-05-23T18:52:05.993644 #71203]  INFO -- request: POST http://localhost:8889/v1/statement
D, [2018-05-23T18:52:05.993719 #71203] DEBUG -- request: User-Agent: "presto-ruby/0.5.10"
X-Presto-User: "arabiki"
X-Presto-Session: "exchange_compression=true, hive.bucket_execution_enabled=false"
I, [2018-05-23T18:52:06.020195 #71203]  INFO -- response: Status 200
D, [2018-05-23T18:52:06.020324 #71203] DEBUG -- response: connection: "close"
date: "Wed, 23 May 2018 09:52:06 GMT"
content-type: "application/json"
x-content-type-options: "nosniff"
content-length: "486"
I, [2018-05-23T18:52:06.021403 #71203]  INFO -- request: GET http://localhost:8889/v1/statement/20180523_095206_00110_t3w9p/1
D, [2018-05-23T18:52:06.021485 #71203] DEBUG -- request: User-Agent: "presto-ruby/0.5.10"
X-Presto-User: "arabiki"
X-Presto-Session: "exchange_compression=true, hive.bucket_execution_enabled=false"
I, [2018-05-23T18:52:06.062935 #71203]  INFO -- response: Status 200
D, [2018-05-23T18:52:06.063055 #71203] DEBUG -- response: connection: "close"
date: "Wed, 23 May 2018 09:52:06 GMT"
content-type: "application/json"
x-content-type-options: "nosniff"
vary: "Accept-Encoding, User-Agent"
content-length: "410"
I, [2018-05-23T18:52:06.063624 #71203]  INFO -- request: GET http://localhost:8889/v1/statement/20180523_095206_00110_t3w9p/2
D, [2018-05-23T18:52:06.063676 #71203] DEBUG -- request: User-Agent: "presto-ruby/0.5.10"
X-Presto-User: "arabiki"
X-Presto-Session: "exchange_compression=true, hive.bucket_execution_enabled=false"
I, [2018-05-23T18:52:06.093063 #71203]  INFO -- response: Status 200
D, [2018-05-23T18:52:06.093186 #71203] DEBUG -- response: connection: "close"
date: "Wed, 23 May 2018 09:52:06 GMT"
content-type: "application/json"
x-content-type-options: "nosniff"
vary: "Accept-Encoding, User-Agent"
content-length: "367"
[1]
```

![image](https://user-images.githubusercontent.com/508822/40417339-7acdc8dc-5eba-11e8-9093-b546eccc1545.png)
