### PR TITLE
Add query timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ $ bundle exec rake modelgen:latest
 * **time_zone** sets time zone of queries. Time zone affects some functions such as `format_datetime`.
 * **language** sets language of queries. Language affects some functions such as `format_datetime`.
 * **properties** set session properties. Session properties affect internal behavior such as `hive.force_local_scheduling: true`, `raptor.reader_stream_buffer_size: "32MB"`, etc.
+* **query_timeout** sets timeout in seconds for the entire query execution (from the first API call until there're no more output data). If timeout happens, client raises PrestoQueryTimeoutError. Default is nil (disabled).
+* **plan_timeout** sets timeout in seconds for query planning execution (from the first API call until result columns become available). If timeout happens, client raises PrestoQueryTimeoutError. Default is nil (disabled).
 * **http_headers** sets custom HTTP headers. It must be a Hash of string to string.
 * **http_proxy** sets host:port of a HTTP proxy server.
 * **http_debug** enables debug message to STDOUT for each HTTP requests.

--- a/lib/presto/client/errors.rb
+++ b/lib/presto/client/errors.rb
@@ -40,4 +40,7 @@ module Presto::Client
 
     attr_reader :error_code, :error_name, :failure_info
   end
+
+  class PrestoQueryTimeoutError < PrestoError
+  end
 end

--- a/lib/presto/client/statement_client.rb
+++ b/lib/presto/client/statement_client.rb
@@ -46,7 +46,7 @@ module Presto::Client
       if @plan_timeout || @query_timeout
         # this is set before the first call of faraday_get_with_retry so that
         # resuming StatementClient with next_uri is also under timeout control.
-        @started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        @query_submitted_at = Time.now
       end
 
       if next_uri
@@ -204,13 +204,13 @@ module Presto::Client
     end
 
     def raise_if_timeout!
-      if @started_at
+      if @query_submitted_at
         if @results && @results.next_uri == nil
           # query is already done
           return
         end
 
-        elapsed = Process.clock_gettime(Process::CLOCK_MONOTONIC) - @started_at
+        elapsed = Time.now - @query_submitted_at
 
         if @query_timeout && elapsed > @query_timeout
           raise_timeout_error!


### PR DESCRIPTION
This change adds two timeout options.
* `query_timeout` is for the entire query execution.
* `plan_timeout` is for query planning.
They are useful for clients who have some realtime requirements (e.g.
query results become useless if query takes more than 60 seconds).
An applicable example is a REST API server that runs a Presto query
synchronously.