### PR TITLE
Use CLOCK_MONOTONIC instead of Time.now for retry timeout

### DIFF
--- a/lib/presto/client/statement_client.rb
+++ b/lib/presto/client/statement_client.rb
@@ -156,7 +156,7 @@ module Presto::Client
     private :parse_body
 
     def faraday_get_with_retry(uri, &block)
-      start = Time.now
+      start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
       attempts = 0
 
       begin
@@ -184,7 +184,7 @@ module Presto::Client
 
         attempts += 1
         sleep attempts * 0.1
-      end while (Time.now - start) < @retry_timeout && !@closed
+      end while (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start) < @retry_timeout && !@closed
 
       @exception = PrestoHttpError.new(408, "Presto API error due to timeout")
       raise @exception


### PR DESCRIPTION
Time.now may cause unexpected timeout when system clock is modified
aggressively. CLOCK_MONOTONIC is a safer replacement.