### PR TITLE
Add a method to get HTTP response headers

### DIFF
--- a/lib/presto/client/query.rb
+++ b/lib/presto/client/query.rb
@@ -50,6 +50,10 @@ module Presto::Client
       @api.current_results
     end
 
+    def current_results_headers
+      @api.current_results_headers
+    end
+
     def advance
       @api.advance
     end

--- a/lib/presto/client/statement_client.rb
+++ b/lib/presto/client/statement_client.rb
@@ -51,6 +51,7 @@ module Presto::Client
 
       if next_uri
         response = faraday_get_with_retry(next_uri)
+        @results_headers = response.headers
         @results = @models::QueryResults.decode(parse_body(response))
       else
         post_query_request!
@@ -78,6 +79,7 @@ module Presto::Client
         raise PrestoHttpError.new(response.status, "Failed to start query: #{response.body} (#{response.status})")
       end
 
+      @results_headers = response.headers
       @results = decode_model(uri, parse_body(response), @models::QueryResults)
     end
 
@@ -111,6 +113,10 @@ module Presto::Client
       @results
     end
 
+    def current_results_headers
+      @results_headers
+    end
+
     def has_next?
       !!@results.next_uri
     end
@@ -122,6 +128,7 @@ module Presto::Client
 
       uri = @results.next_uri
       response = faraday_get_with_retry(uri)
+      @results_headers = response.headers
       @results = decode_model(uri, parse_body(response), @models::QueryResults)
 
       raise_if_timeout!

--- a/spec/statement_client_spec.rb
+++ b/spec/statement_client_spec.rb
@@ -132,6 +132,22 @@ describe Presto::Client::StatementClient do
     end.should raise_error(TypeError, /String to Hash/)
   end
 
+  it "receives headers of POST" do
+    stub_request(:post, "localhost/v1/statement").
+      with(body: query).to_return(body: response_json2.to_json, headers: {"X-Test-Header" => "123"})
+
+    sc = StatementClient.new(faraday, query, options.merge(http_open_timeout: 1))
+    sc.current_results_headers["X-Test-Header"].should == "123"
+  end
+
+  it "receives headers of POST through Query" do
+    stub_request(:post, "localhost/v1/statement").
+      with(body: query).to_return(body: response_json2.to_json, headers: {"X-Test-Header" => "123"})
+
+    q = Presto::Client.new(options).query(query)
+    q.current_results_headers["X-Test-Header"].should == "123"
+  end
+
   describe '#query_info' do
     let :headers do
       {


### PR DESCRIPTION
HTTP proxy servers in front of Presto (such as Prestobase) have
opportunity to add custom HTTP headers as well as processing custom HTTP
request headers. presto-client-ruby has options to set request headers.
This change adds a method to get response headers.