### PR TITLE
Make more similar to recent java StatementClient

### DIFF
--- a/lib/presto/client/query.rb
+++ b/lib/presto/client/query.rb
@@ -130,11 +130,8 @@ module Presto::Client
     end
 
     def raise_if_failed
-      if @api.closed?
+      if @api.client_aborted?
         raise PrestoClientError, "Query aborted by user"
-      elsif @api.exception?
-        # query is gone
-        raise @api.exception
       elsif @api.query_failed?
         results = @api.current_results
         error = results.error

--- a/spec/statement_client_spec.rb
+++ b/spec/statement_client_spec.rb
@@ -138,6 +138,27 @@ describe Presto::Client::StatementClient do
         })
       end.should raise_error(TypeError, /String to Hash/)
     end
+  else
+    it "decodes DeleteTarget" do
+      dh = Models::DeleteTarget.decode({
+        "handle" => {
+          "catalogName" => "c1",
+          "connectorHandle" => {}
+        }
+      })
+      dh.handle.should be_a_kind_of Models::TableHandle
+      dh.handle.catalog_name.should == "c1"
+      dh.handle.connector_handle.should == {}
+    end
+
+    it "validates models" do
+      lambda do
+        Models::DeleteTarget.decode({
+          "catalogName" => "c1",
+          "handle" => "invalid"
+        })
+      end.should raise_error(TypeError, /String to Hash/)
+    end
   end
 
   it "receives headers of POST" do
@@ -588,11 +609,13 @@ describe Presto::Client::StatementClient do
         to_return(body: early_running_response.to_json)
       client.advance
 
-      sleep 1
       stub_request(:get, "localhost/v1/next_uri").
         with(headers: headers).
         to_return(body: done_response.to_json)
-      client.advance
+      client.advance # set finished
+
+      sleep 1
+      client.advance # set finished
     end
 
   end


### PR DESCRIPTION
Basically {{statement_client.close}} behaves differently with Java's StatementClient. It looks like there's no side-effect even in the current logic, calling {{DELETE /v1/query/<query-id>}} at the end of every query.

But it would make subtle issue in the future and it can save one http call :-) 