### PR TITLE
Url encode session properties

### DIFF
--- a/lib/presto/client/faraday_client.rb
+++ b/lib/presto/client/faraday_client.rb
@@ -15,6 +15,8 @@
 #
 module Presto::Client
 
+  require 'cgi'
+
   module PrestoHeaders
     PRESTO_USER = "X-Presto-User"
     PRESTO_SOURCE = "X-Presto-Source"
@@ -155,6 +157,7 @@ module Presto::Client
       if field_value =~ HTTP11_CTL_CHARSET_REGEXP
         raise Faraday::ClientError, "Value of properties can't include HTTP/1.1 control characters"
       end
+      field_value = CGI.escape(field_value)
       "#{token}=#{field_value}"
     end
   end


### PR DESCRIPTION
Since presto version 306, presto server expects encoded session properties https://github.com/prestosql/presto/commit/db1fa3a25a42f074c63d9144fc4b34b86741b070 . 