### PR TITLE
Implement `StatementClient#query_id`

### DIFF
--- a/lib/presto/client/statement_client.rb
+++ b/lib/presto/client/statement_client.rb
@@ -117,6 +117,10 @@ module Presto::Client
       @results_headers
     end
 
+    def query_id
+      @results.id
+    end
+
     def has_next?
       !!@results.next_uri
     end

--- a/spec/statement_client_spec.rb
+++ b/spec/statement_client_spec.rb
@@ -148,6 +148,22 @@ describe Presto::Client::StatementClient do
     q.current_results_headers["X-Test-Header"].should == "123"
   end
 
+  describe "#query_id" do
+    it "returns query_id" do
+      stub_request(:post, "localhost/v1/statement").
+        with(body: query).to_return(body: response_json2.to_json, headers: {"X-Test-Header" => "123"})
+
+     stub_request(:get, "localhost/v1/next_uri").
+        to_return(body: response_json.to_json, headers: {"X-Test-Header" => "123"})
+
+      sc = StatementClient.new(faraday, query, options.merge(http_open_timeout: 1))
+      sc.query_id.should == "queryid"
+      sc.has_next?.should be_true
+      sc.advance.should be_true
+      sc.query_id.should == "queryid"
+    end
+  end
+
   describe '#query_info' do
     let :headers do
       {


### PR DESCRIPTION
We need to know presto query id to kill the query then providing `StatementClient#query_id` as shorthand of `@results.id` will be useful.