### PR TITLE
Test with presto docker container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 rvm:
-  - 2.3.8
-  - 2.4.9
   - 2.5.7
   - 2.6.5
+  - 2.7.0
 
 script: "bundle exec rake spec"
 
 sudo: false
+
+services:
+  - docker
 
 notifications:
   webhooks: http://td-beda.herokuapp.com/travisci_callback

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,6 @@
 source 'https://rubygems.org/'
 gemspec
+
+group :development, :test do
+  gem 'tiny-presto', '~> 0.0.5'
+end

--- a/spec/basic_query_spec.rb
+++ b/spec/basic_query_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+
+describe Presto::Client::Client do
+  before(:all) do
+    WebMock.disable!
+    @cluster = TinyPresto::Cluster.new('316')
+    @container = @cluster.run
+    @client = Presto::Client.new(server: 'localhost:8080', catalog: 'memory', user: 'test-user', schema: 'default')
+    loop do
+      begin
+        @client.run('show schemas')
+        break
+      rescue StandardError => exception
+        puts "Waiting for cluster ready... #{exception}"
+        sleep(3)
+      end
+    end
+    puts 'Cluster is ready'
+  end
+
+  after(:all) do
+    @cluster.stop
+    WebMock.enable!
+  end
+
+  it 'show schemas' do
+    columns, rows = run_with_retry(@client, 'show schemas')
+    expect(columns.length).to be(1)
+    expect(rows.length).to be(2)
+  end
+
+  it 'ctas' do
+    expected = [[1, 'a'], [2, 'b']]
+    run_with_retry(@client, "create table ctas1 as select * from (values (1, 'a'), (2, 'b')) t(c1, c2)")
+    columns, rows = run_with_retry(@client, 'select * from ctas1')
+    expect(columns.map(&:name)).to match_array(%w[c1 c2])
+    expect(rows).to eq(expected)
+  end
+
+  it 'next_uri' do
+    @client.query('show schemas') do |q|
+      expect(q.next_uri).to start_with('http://localhost:8080/v1/statement/')
+    end
+  end
+
+  it 'advance' do
+    @client.query('show schemas') do |q|
+      expect(q.advance).to be(true)
+    end
+  end
+
+  it 'current query result' do
+    @client.query('show schemas') do |q|
+      expect(q.current_results.info_uri).to start_with('http://localhost:8080/ui/query.html')
+    end
+  end
+
+  it 'statement stats' do
+    @client.query('show schemas') do |q|
+      stats = q.current_results.stats
+      # Immediate subsequent request should get queued result
+      expect(stats.queued).to be(true)
+      expect(stats.scheduled).to be(false)
+    end
+  end
+
+  it 'partial cancel' do
+    @client.query('show schemas') do |q|
+      q.cancel
+      expect { q.query_info }.to raise_error(Presto::Client::PrestoHttpError, /Error 410 Gone/)
+    end
+  end
+
+  it 'row chunk' do
+    expected_schemas = %w[default information_schema]
+    @client.query('show schemas') do |q|
+      q.each_row do |r|
+        expect(expected_schemas).to include(r[0])
+      end
+    end
+  end
+end

--- a/spec/tpch/q01.sql
+++ b/spec/tpch/q01.sql
@@ -1,0 +1,21 @@
+SELECT
+  l.returnflag,
+  l.linestatus,
+  sum(l.quantity)                                       AS sum_qty,
+  sum(l.extendedprice)                                  AS sum_base_price,
+  sum(l.extendedprice * (1 - l.discount))               AS sum_disc_price,
+  sum(l.extendedprice * (1 - l.discount) * (1 + l.tax)) AS sum_charge,
+  avg(l.quantity)                                       AS avg_qty,
+  avg(l.extendedprice)                                  AS avg_price,
+  avg(l.discount)                                       AS avg_disc,
+  count(*)                                              AS count_order
+FROM
+  "tpch"."tiny"."lineitem" AS l
+WHERE
+  l.shipdate <= DATE '1998-12-01' - INTERVAL '90' DAY
+GROUP BY
+  l.returnflag,
+  l.linestatus
+ORDER BY
+  l.returnflag,
+  l.linestatus

--- a/spec/tpch/q02.sql
+++ b/spec/tpch/q02.sql
@@ -1,0 +1,43 @@
+SELECT
+  s.acctbal,
+  s.name,
+  n.name,
+  p.partkey,
+  p.mfgr,
+  s.address,
+  s.phone,
+  s.comment
+FROM
+  "tpch"."tiny"."part" p,
+  "tpch"."tiny"."supplier" s,
+  "tpch"."tiny"."partsupp" ps,
+  "tpch"."tiny"."nation" n,
+  "tpch"."tiny"."region" r
+WHERE
+  p.partkey = ps.partkey
+  AND s.suppkey = ps.suppkey
+  AND p.size = 15
+  AND p.type like '%BRASS'
+  AND s.nationkey = n.nationkey
+  AND n.regionkey = r.regionkey
+  AND r.name = 'EUROPE'
+  AND ps.supplycost = (
+    SELECT
+      min(ps.supplycost)
+    FROM
+      "tpch"."tiny"."partsupp" ps,
+      "tpch"."tiny"."supplier" s,
+      "tpch"."tiny"."nation" n,
+      "tpch"."tiny"."region" r
+    WHERE
+      p.partkey = ps.partkey
+      AND s.suppkey = ps.suppkey
+      AND s.nationkey = n.nationkey
+      AND n.regionkey = r.regionkey
+      AND r.name = 'EUROPE'
+  )
+ORDER BY
+  s.acctbal desc,
+  n.name,
+  s.name,
+  p.partkey

--- a/spec/tpch_query_spec.rb
+++ b/spec/tpch_query_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe Presto::Client::Client do
+  before(:all) do
+    @spec_path = File.dirname(__FILE__)
+    WebMock.disable!
+    @cluster = TinyPresto::Cluster.new('316')
+    @container = @cluster.run
+    @client = Presto::Client.new(server: 'localhost:8080', catalog: 'tpch', user: 'test-user', schema: 'tiny')
+    loop do
+      begin
+        # Make sure to all workers are available.
+        @client.run('select 1234')
+        break
+      rescue StandardError => exception
+        puts "Waiting for cluster ready... #{exception}"
+        sleep(5)
+      end
+    end
+    puts 'Cluster is ready'
+  end
+
+  after(:all) do
+    @cluster.stop
+    WebMock.enable!
+  end
+
+  it 'q01' do
+    q = File.read("#{@spec_path}/tpch/q01.sql")
+    columns, rows = run_with_retry(@client, q)
+    expect(columns.length).to be(10)
+    expect(rows.length).to be(4)
+  end
+
+  it 'q02' do
+    q = File.read("#{@spec_path}/tpch/q02.sql")
+    columns, rows = run_with_retry(@client, q)
+    expect(columns.length).to be(8)
+    expect(rows.length).to be(4)
+  end
+end


### PR DESCRIPTION
# Purpose
To improve test coverage, we can use a docker container and run queries on it. Thanks to that, we can expect slight coverage improvement to check the compatibility with several versions. 

# Overview

- Add specs to run the docker container of Presto.
- Run TPCH queries to ensure basic queries runnable.
- Improve test coverage for several APIs provided by presto-client-ruby.

# Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary