### PR TITLE
Add follow_redirect option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ client = Presto::Client.new(
   },
   http_proxy: "proxy.example.com:8080",
   http_debug: true,
+  follow_redirect: true
 )
 
 # run a query and get results as an array of arrays:

--- a/lib/presto/client/faraday_client.rb
+++ b/lib/presto/client/faraday_client.rb
@@ -60,7 +60,7 @@ module Presto::Client
       if options[:user] && options[:password]
         faraday.basic_auth(options[:user], options[:password])
       end
-      if options[:follow_redirect] == true
+      if options[:follow_redirect]
         faraday.use FaradayMiddleware::FollowRedirects
       end
       faraday.response :logger if options[:http_debug]

--- a/lib/presto/client/faraday_client.rb
+++ b/lib/presto/client/faraday_client.rb
@@ -60,7 +60,9 @@ module Presto::Client
       if options[:user] && options[:password]
         faraday.basic_auth(options[:user], options[:password])
       end
-
+      if options[:follow_redirect] == true
+        faraday.use FaradayMiddleware::FollowRedirects
+      end
       faraday.response :logger if options[:http_debug]
       faraday.adapter Faraday.default_adapter
     end

--- a/lib/presto/client/query.rb
+++ b/lib/presto/client/query.rb
@@ -16,6 +16,7 @@
 module Presto::Client
 
   require 'faraday'
+  require 'faraday_middleware'
   require 'presto/client/models'
   require 'presto/client/errors'
   require 'presto/client/faraday_client'

--- a/presto-client.gemspec
+++ b/presto-client.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 1.9.1"
 
   gem.add_dependency "faraday", ["~> 0.12"]
+  gem.add_dependency "faraday_middleware", ["~> 0.12.2"]
     gem.add_dependency "msgpack", [">= 0.7.0"]
 
   gem.add_development_dependency "rake", [">= 0.9.2", "< 11.0"]


### PR DESCRIPTION
# Purpose

Add follow_redirect option

# Overview

```ruby
client = Presto::Client.new(
  server: "localhost:8880",   # required option
  ssl: {verify: false},
  catalog: "native",
  schema: "default",
  user: "frsyuki",
  password: "********",
  time_zone: "US/Pacific",
  language: "English",
  properties: {
    "hive.force_local_scheduling": true,
    "raptor.reader_stream_buffer_size": "32MB"
  },
  http_proxy: "proxy.example.com:8080",
  http_debug: true,
  follow_redirect: true # add this option
)
```

# Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary