### PR TITLE
Add gzip option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ $ bundle exec rake modelgen:latest
 * **http_debug** enables debug message to STDOUT for each HTTP requests.
 * **http_open_timeout** sets timeout in seconds to open new HTTP connection.
 * **http_timeout** sets timeout in seconds to read data from a server.
+* **gzip** enables gzip compression.
 * **follow_redirect** enables HTTP redirection support.
 * **model_version** set the presto version to which a job is submitted. Supported versions are 316, 303, 0.205, 0.178, 0.173, 0.153 and 0.149. Default is 316.
 

--- a/lib/presto/client/faraday_client.rb
+++ b/lib/presto/client/faraday_client.rb
@@ -63,6 +63,9 @@ module Presto::Client
       if options[:follow_redirect]
         faraday.use FaradayMiddleware::FollowRedirects
       end
+      if options[:gzip]
+        faraday.use FaradayMiddleware::Gzip
+      end
       faraday.response :logger if options[:http_debug]
       faraday.adapter Faraday.default_adapter
     end

--- a/spec/gzip_spec.rb
+++ b/spec/gzip_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe Presto::Client::Client do
+  before(:all) do
+    @spec_path = File.dirname(__FILE__)
+    WebMock.disable!
+    @cluster = TinyPresto::Cluster.new('ghcr.io/trinodb/presto', '316')
+    @container = @cluster.run
+    @client = Presto::Client.new(server: 'localhost:8080', catalog: 'tpch', user: 'test-user', schema: 'tiny', gzip: true, http_debug: true)
+    loop do
+      begin
+        # Make sure to all workers are available.
+        @client.run('select 1234')
+        break
+      rescue StandardError => exception
+        puts "Waiting for cluster ready... #{exception}"
+        sleep(5)
+      end
+    end
+    puts 'Cluster is ready'
+  end
+
+  after(:all) do
+    @cluster.stop
+    WebMock.enable!
+  end
+
+  it 'tpch q01 with gzip option' do
+    $stdout = StringIO.new
+    begin
+      q = File.read("#{@spec_path}/tpch/q01.sql")
+      columns, rows = run_with_retry(@client, q)
+      expect(columns.length).to be(10)
+      expect(rows.length).to be(4)
+      expect($stdout.string).to include ('content-encoding: "gzip"')
+    ensure
+      $stdout = STDOUT
+    end
+  end
+end


### PR DESCRIPTION
# Purpose

Add `gzip` option which enables gzip compression

# Overview

```ruby
client = Presto::Client.new(
  server: "localhost:8080",
  ssl: false,
  catalog: "native",
  schema: "default",
  user: "frsyuki",
  password: "********",
  http_debug: true,
  gzip: true # Add this option
)
```

# Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary