### PR TITLE
Pull presto docker image from GitHub Container Registry for testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,5 @@ source 'https://rubygems.org/'
 gemspec
 
 group :development, :test do
-  gem 'tiny-presto', '~> 0.0.5'
+  gem 'tiny-presto', '~> 0.0.7'
 end

--- a/spec/basic_query_spec.rb
+++ b/spec/basic_query_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Presto::Client::Client do
   before(:all) do
     WebMock.disable!
-    @cluster = TinyPresto::Cluster.new('316')
+    @cluster = TinyPresto::Cluster.new('ghcr.io/trinodb/presto', '316')
     @container = @cluster.run
     @client = Presto::Client.new(server: 'localhost:8080', catalog: 'memory', user: 'test-user', schema: 'default')
     loop do

--- a/spec/tpch_query_spec.rb
+++ b/spec/tpch_query_spec.rb
@@ -4,7 +4,7 @@ describe Presto::Client::Client do
   before(:all) do
     @spec_path = File.dirname(__FILE__)
     WebMock.disable!
-    @cluster = TinyPresto::Cluster.new('316')
+    @cluster = TinyPresto::Cluster.new('ghcr.io/trinodb/presto', '316')
     @container = @cluster.run
     @client = Presto::Client.new(server: 'localhost:8080', catalog: 'tpch', user: 'test-user', schema: 'tiny')
     loop do


### PR DESCRIPTION
# Purpose

Pull presto docker image from GitHub Container Registry for testing

# Overview

Because prestosql docker images have been removed due to the transition from prestosql to trino, we cannot pull prestosql docker images for testing from DockerHub any more. However, these older docker images have been backup at GitHub Container Registry. We can use them instead.
https://github.com/orgs/trinodb/packages/container/package/presto

- Bump tiny-presto library to 0.0.7 to use arbitrary docker image
- Use `ghcr.io/trinodb/presto:316` for testing

# Checklist

- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary